### PR TITLE
feat: Add simple A2A echo example and update documentation

### DIFF
--- a/ai-engineering-studio/agents/README.md
+++ b/ai-engineering-studio/agents/README.md
@@ -10,3 +10,18 @@ Supports Key Enterprise Requirements: Offers core functionalities essential for 
 
 Referencees:
 - https://developers.googleblog.com/en/a2a-a-new-era-of-agent-interoperability/ 
+
+
+## Getting Started with an Example
+
+To help you understand the Agent2Agent (A2A) protocol in practice, a simple "Echo Agent" example is available in this repository. This example demonstrates the basic principles of A2A, including:
+
+*   Defining an agent's capabilities (Agent Card and Skills).
+*   Implementing the agent's logic (Agent Executor).
+*   Running an A2A server.
+*   Creating a client to interact with the agent.
+
+You can find the example and instructions on how to run it here:
+*   [Simple A2A Echo Example](./a2a_example/README.md)
+
+**Note:** This example requires Python 3.13+ due to the `a2a-sdk` dependency.

--- a/ai-engineering-studio/agents/a2a_example/README.md
+++ b/ai-engineering-studio/agents/a2a_example/README.md
@@ -1,0 +1,65 @@
+# Simple A2A Echo Example
+
+This example demonstrates a basic Agent2Agent (A2A) protocol interaction using the Python SDK. It consists of a simple "Echo Agent" (server) and a client that communicates with it.
+
+**Important: Python Version Requirement**
+This example requires **Python 3.13 or newer** due to the `a2a-sdk` dependency. The environment where this example was generated uses an older Python version, so these scripts could not be run there. Please ensure you have Python 3.13+ if you intend to execute this example.
+
+## Components
+
+1.  **`a2a_example_server.py`**:
+    *   Implements the "Echo Agent".
+    *   This agent has one skill: to echo back any text message it receives.
+    *   It defines an Agent Card to advertise its capabilities.
+    *   It runs an HTTP server on `http://localhost:8008`.
+
+2.  **`a2a_example_client.py`**:
+    *   Implements a client that connects to the Echo Agent.
+    *   It fetches the agent's card, then sends a text message.
+    *   It prints the response received from the agent.
+
+## How to Run (in a Python 3.13+ environment)
+
+1.  **Install Dependencies:**
+    Open your terminal and ensure your environment has Python 3.13+. Then install the necessary packages:
+    ```bash
+    pip install "a2a-sdk>=0.0.10" uvicorn httpx
+    ```
+
+2.  **Start the Server:**
+    In one terminal, navigate to the `ai-engineering-studio/agents/a2a_example` directory and run:
+    ```bash
+    python a2a_example_server.py
+    ```
+    The server should start and listen on port 8008.
+
+3.  **Run the Client:**
+    In another terminal, navigate to the `ai-engineering-studio/agents/a2a_example` directory and run:
+    ```bash
+    python a2a_example_client.py
+    ```
+    The client will send a message to the server and print the echoed response.
+
+## Expected Output (Client)
+
+The client should print a JSON response similar to this (IDs will vary):
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "result": {
+    "type": "message",
+    "role": "agent",
+    "parts": [
+      {
+        "type": "text",
+        "text": "Hello A2A Echo Agent!"
+      }
+    ],
+    "messageId": "yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy",
+    "annotations": null
+  }
+}
+```
+This demonstrates the server echoing the client's message.

--- a/ai-engineering-studio/agents/a2a_example/a2a_example_client.py
+++ b/ai-engineering-studio/agents/a2a_example/a2a_example_client.py
@@ -1,0 +1,26 @@
+import asyncio
+import uuid
+import httpx
+from a2a.client import A2AClient
+from a2a.types import MessageSendParams
+
+async def main():
+    async with httpx.AsyncClient() as httpx_client:
+        client = await A2AClient.get_client_from_agent_card_url(
+            httpx_client, "http://localhost:8008/"
+        )
+
+        message_text = "Hello A2A Echo Agent!"
+        send_message_payload = {
+            "message": {
+                "role": "user",
+                "parts": [{"type": "text", "text": message_text}],
+                "messageId": uuid.uuid4().hex,
+            }
+        }
+        request = MessageSendParams(**send_message_payload)
+        response = await client.send_message(request)
+        print("Server response:", response.model_dump_json(exclude_none=True))
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/ai-engineering-studio/agents/a2a_example/a2a_example_client.py
+++ b/ai-engineering-studio/agents/a2a_example/a2a_example_client.py
@@ -19,7 +19,17 @@ async def main():
             }
         }
         request = MessageSendParams(**send_message_payload)
-        response = await client.send_message(request)
+}
+        }
+        request = MessageSendParams(**send_message_payload)
+        try:
+            response = await client.send_message(request)
+            print("Server response:", response.model_dump_json(exclude_none=True))
+        except Exception as e:
+            print(f"Error sending message: {e}")
+
+if __name__ == "__main__":
+    asyncio.run(main())
         print("Server response:", response.model_dump_json(exclude_none=True))
 
 if __name__ == "__main__":

--- a/ai-engineering-studio/agents/a2a_example/a2a_example_server.py
+++ b/ai-engineering-studio/agents/a2a_example/a2a_example_server.py
@@ -52,7 +52,14 @@ class EchoAgentExecutor(AgentExecutor):
         event_queue.put_nowait(response_message)
         event_queue.put_nowait(None)  # Signal end of events
 
+event_queue.put_nowait(None)  # Signal end of events
+
     async def cancel(self):
+        # TODO: Implement basic cancellation mechanism
+        print("Cancellation requested, but not implemented yet.")
+
+# 6. Server Setup
+if __name__ == "__main__":
         raise NotImplementedError("Cancel not supported")
 
 # 6. Server Setup

--- a/ai-engineering-studio/agents/a2a_example/a2a_example_server.py
+++ b/ai-engineering-studio/agents/a2a_example/a2a_example_server.py
@@ -45,7 +45,25 @@ class EchoAgentExecutor(AgentExecutor):
     def __init__(self):
         self.logic = EchoAgentLogic()
 
+self.logic = EchoAgentLogic()
+
     async def execute(self, context: RequestContext, event_queue: EventQueue):
+        try:
+            text_to_echo = context.request.params.message.parts[0].text
+            echoed_text = await self.logic.echo(text_to_echo)
+            response_message = new_agent_text_message(echoed_text)
+            event_queue.put_nowait(response_message)
+        except IndexError:
+            error_message = new_agent_text_message("Error: No message parts found.")
+            event_queue.put_nowait(error_message)
+        except Exception as e:
+            error_message = new_agent_text_message(f"An error occurred: {str(e)}")
+            event_queue.put_nowait(error_message)
+        finally:
+            event_queue.put_nowait(None)  # Signal end of events
+
+    async def cancel(self):
+        raise NotImplementedError("Cancel not supported")
         text_to_echo = context.request.params.message.parts[0].text
         echoed_text = await self.logic.echo(text_to_echo)
         response_message = new_agent_text_message(echoed_text)

--- a/ai-engineering-studio/agents/a2a_example/a2a_example_server.py
+++ b/ai-engineering-studio/agents/a2a_example/a2a_example_server.py
@@ -1,0 +1,67 @@
+import asyncio
+import uvicorn
+from a2a.server.agent_execution import AgentExecutor, EventQueue, RequestContext
+from a2a.server.apps import A2AStarletteApplication
+from a2a.server.request_handlers import DefaultRequestHandler
+from a2a.server.tasks import InMemoryTaskStore
+from a2a.types import (
+    AgentCard,
+    AgentCapabilities,
+    AgentSkill,
+    Message,
+)
+from a2a.utils import new_agent_text_message
+
+# 2. Agent Skill
+echo_skill = AgentSkill(
+    id="echo_skill",
+    name="Echoes the input",
+    description="A simple skill that takes a text message and returns it.",
+    tags=["echo", "example"],
+    examples=["echo hello", "say something"],
+    input_modes=["text/plain"],
+    output_modes=["text/plain"],
+)
+
+# 3. Agent Card
+echo_agent_card = AgentCard(
+    name="EchoAgent",
+    description="A simple A2A agent that echoes text messages.",
+    url="http://localhost:8008/",
+    version="0.1.0",
+    default_input_modes=["text/plain"],
+    default_output_modes=["text/plain"],
+    capabilities=AgentCapabilities(streaming=False),
+    skills=[echo_skill],
+)
+
+# 4. Agent Logic
+class EchoAgentLogic:
+    async def echo(self, text: str) -> str:
+        return text
+
+# 5. Agent Executor
+class EchoAgentExecutor(AgentExecutor):
+    def __init__(self):
+        self.logic = EchoAgentLogic()
+
+    async def execute(self, context: RequestContext, event_queue: EventQueue):
+        text_to_echo = context.request.params.message.parts[0].text
+        echoed_text = await self.logic.echo(text_to_echo)
+        response_message = new_agent_text_message(echoed_text)
+        event_queue.put_nowait(response_message)
+        event_queue.put_nowait(None)  # Signal end of events
+
+    async def cancel(self):
+        raise NotImplementedError("Cancel not supported")
+
+# 6. Server Setup
+if __name__ == "__main__":
+    executor = EchoAgentExecutor()
+    request_handler = DefaultRequestHandler(
+        executor=executor, task_store=InMemoryTaskStore()
+    )
+    app = A2AStarletteApplication(
+        agent_card=echo_agent_card, request_handler=request_handler
+    )
+    uvicorn.run(app.build(), host="0.0.0.0", port=8008)


### PR DESCRIPTION
Adds a basic Agent2Agent (A2A) echo example to `ai-engineering-studio/agents/a2a_example/`.

This example includes:
- `a2a_example_server.py`: A server implementing a simple echo agent that listens on localhost:8008. It defines an Agent Card and uses an Agent Executor to echo back received text messages.
- `a2a_example_client.py`: A client that connects to the echo agent, sends a message, and prints the response.
- `a2a_example/README.md`: Detailed instructions on how to run the example, its components, and expected output.

The main `ai-engineering-studio/agents/README.md` has been updated to introduce this example and provide a link to it.

Note: The `a2a-sdk` used in this example requires Python 3.13+. This requirement is documented in the READMEs.